### PR TITLE
add authors record to gemspec

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,7 @@ Add this line to your applications `Gemfile`
 Next run
 
     bundle install
-    rails g refinerycms:snippets
+    rails g refinery:snippets
     rake db:migrate
 
 ## Usage

--- a/refinerycms-snippets.gemspec
+++ b/refinerycms-snippets.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |s|
   s.summary           = 'Snippets extension for Refinery CMS'
   s.require_paths     = %w(lib)
   s.files             = Dir["{app,config,db,lib}/**/*"] + ["readme.md"]
-
+  s.authors           = 'Alexander Nеgоdа'
   # Runtime dependencies
   s.add_dependency             'refinerycms-core',    '~> 3.0.0'
   s.add_dependency             'acts_as_indexed',     '~> 0.8.0'


### PR DESCRIPTION
This fix 'Could not find refinerycms-snippets-1.0 in any of the sources (Bundler::GemNotFound)' bundle error

Thank you for this plugin.
